### PR TITLE
fix(server): fix parsing lyrics in uncommon format

### DIFF
--- a/packages/server/src/api/netease/song.ts
+++ b/packages/server/src/api/netease/song.ts
@@ -10,12 +10,12 @@ const resolveLyric = (
   const unsorted: Array<[number, string]> = [];
   const lines = raw.split("\n");
   for (const line of lines) {
-    const r = /^\[(\d{2}):(\d{2})(?:[.:](\d{2,3}))\](.*)$/g.exec(line.trim());
+    const r = /^\[(\d+):(\d{2})(?:[.:](\d{2,3}))\](.*)$/g.exec(line.trim());
     if (!r) continue;
     const minute = parseInt(r[1]);
     const second = parseInt(r[2]);
     const millisecond = parseInt(r[3].length === 2 ? `${r[3]}0` : r[3]);
-    unsorted.push([minute * 60 + second + millisecond / 1000, r[4] ?? ""]);
+    unsorted.push([minute * 60 + second + millisecond / 1000, r[4]?.trim() ?? ""]);
   }
 
   unsorted.sort(([a], [b]) => a - b);


### PR DESCRIPTION
The lyric of song [仲村芽衣子 - Scarlet Faith](https://music.163.com/#/song?id=28812025) is:

```text
[00:00.000] 作词 : 仲村芽衣子
[00:00.000] 作曲 : 水夏える
[0:00.000]
[0:14.880]離れて君を手繰るその指は
[0:18.480]ただ儚い時を辿って
[0:21.280]終わらない夢を彷徨い続けた
[0:24.770]迷い無き僕の目で
[0:28.000]熱き鼓動を響かせて
[0:31.400]
[0:37.750]
[0:43.910]この両手が歪ませた
[0:47.080]罪と制裁の狭間で
[0:50.230]塵に紛れて 錆び付く刃
[0:55.250]
[0:56.330]何が正義であるべきか
[0:59.750]その目で見つめた物が
[1:03.000]答えじゃないのならば
[1:06.100]何を信じればいい？
[1:09.530]
[1:10.540]A change out その日 was my sanctuary
[1:14.080]その声が胸を焦がして
[1:16.880]走り出す影が届かない場所へ
[1:20.450]消えてしまう前に 抱きしめに行く
[1:23.230]
[1:23.840]離れて君を手繰るその指は
[1:26.800]ただ儚い時を辿って
[1:29.620]終わらない夢を彷徨い続けた
[1:33.140]迷い無き僕の目で
[1:36.370]熱き鼓動を響かせて
[1:39.740]
[1:45.840]まだ芽生えたての種が
[1:49.090]古き戦場に塗れて
[1:52.210]息を殺して流した涙
[1:57.220]
[1:58.380]やがて事実は凌がれて
[2:01.800]行き場のないこの声が
[2:04.940]世界を枯らすのなら
[2:08.130]壊してしまえばいい
[2:11.520]
[2:12.520]Another to change out my precious life and history
[2:16.100]未来を抜き 今スピード上げ
[2:18.880]届かないなんて諦める前に
[2:22.450]握り締めた剣 振りかざし続け
[2:25.250]
[2:25.820]終わらない夢を彷徨い続けて
[2:28.800]僕の目は炎宿して
[2:31.570]空を舞う灰が降り注いでいた
[2:35.120]味気ないこの世界
[2:38.340]君という光で溶かして
[2:41.730]
[2:49.690]...music...
[3:05.570]
[3:08.140]佇むものは星の数ほどに
[3:11.730]発つ者は一握りだけ
[3:14.480]意味があるようで でも見つからずに
[3:18.010]進む戦火の海駆け抜けた 降り注ぐ灰
[3:22.460]
[3:23.040]A change out その日 was my sanctuary
[3:25.980]その声が胸が焦がして
[3:28.790]走り出す影が届かない場所へ
[3:32.340]消えてしまう前に 抱きしめに行く
[3:35.100]
[3:35.750]まだ終わらない 手繰るその指は
[3:38.700]ただ儚い時を辿って
[3:41.500]守りたいだから 刃をかざした
[3:45.070]迷い無き僕の目で
[3:48.270]願うのはみな同じ
[3:51.250]そうどこまでも切り裂いて
[3:56.430]
[4:09.160]-END-
```

From the third line, the timestamps are in `[0:00.000]` format, instead of the commonly found `[00:00.000]`.

With current parsing logic, all those lines will be discarded.

![image](https://user-images.githubusercontent.com/1330321/124240575-72356a00-db4d-11eb-83cd-0292b7797d3c.png)

This PR allows minute number in any length, thus fixing parsing such lines. It also trims leading and trailing spaces from each line to better align with official web player.

![image](https://user-images.githubusercontent.com/1330321/124240877-c8a2a880-db4d-11eb-9aaf-df8a111b9078.png)
